### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # devilutionx-snapcraft
+
+Snap packaging configuration for [DevilutionX](https://github.com/diasurgical/devilutionX)


### PR DESCRIPTION
Also i think it might not be necessary to have libsodium23 as a runtime dependency as it is statically linked when building with BINARY_RELEASE